### PR TITLE
Removes Scala 2.9.1 deprecation warnings for method exit

### DIFF
--- a/src/main/scala/scopt/Options.scala
+++ b/src/main/scala/scopt/Options.scala
@@ -370,10 +370,10 @@ case class OptionParser(
     add(new KeyBooleanValueArgOptionDefinition(shortopt, longopt, keyName, valueName, description, action))
   
   def help(shortopt: String, longopt: String, description: String) =
-    add(new FlagOptionDefinition(Some(shortopt), longopt, description, {this.showUsage; exit}))
+    add(new FlagOptionDefinition(Some(shortopt), longopt, description, {this.showUsage; sys.exit}))
 
   def help(shortopt: Option[String], longopt: String, description: String) =
-    add(new FlagOptionDefinition(shortopt, longopt, description, {this.showUsage; exit}))
+    add(new FlagOptionDefinition(shortopt, longopt, description, {this.showUsage; sys.exit}))
   
   def separator(description: String) =
     add(new SeparatorDefinition(description))


### PR DESCRIPTION
No big deal, but I figured it could be useful anyway :)
